### PR TITLE
Use complete_sso_login from Synapse instead of re-implementing it

### DIFF
--- a/matrix_synapse_saml_mozilla/username_picker.py
+++ b/matrix_synapse_saml_mozilla/username_picker.py
@@ -171,13 +171,6 @@ class SubmitResource(AsyncResource):
 
         del username_mapping_sessions[session_id]
 
-        login_token = self._module_api.generate_short_term_login_token(
-            registered_user_id
-        )
-        redirect_url = _add_login_token_to_redirect_url(
-            session.client_redirect_url, login_token
-        )
-
         # delete the cookie
         request.addCookie(
             SESSION_COOKIE_NAME,
@@ -185,8 +178,12 @@ class SubmitResource(AsyncResource):
             expires=b"Thu, 01 Jan 1970 00:00:00 GMT",
             path=b"/",
         )
-        request.redirect(redirect_url)
-        request.finish()
+
+        self._module_api.complete_sso_login(
+            registered_user_id,
+            request,
+            session.client_redirect_url,
+        )
 
 
 class AvailabilityCheckResource(AsyncResource):


### PR DESCRIPTION
It's still a bit hacky that `saml_response_to_user_attributes` hijacks part of the SAML flow, but at least that part isn't duplicated anymore.

~Depends on https://github.com/matrix-org/synapse/pull/7007~