### PR TITLE
Print a (prettier) error if the chosen username contains uppercase characters

### DIFF
--- a/matrix_synapse_saml_mozilla/res/script.js
+++ b/matrix_synapse_saml_mozilla/res/script.js
@@ -36,13 +36,13 @@ let onResponse = function(response, success) {
 };
 
 // We allow upper case characters here, but then lowercase before sending to the server
-let allowedUsernameCharacters = RegExp("[^a-zA-Z0-9\\.\\_\\=\\-\\/]");
+let allowedUsernameCharacters = RegExp("[^a-z0-9\\.\\_\\=\\-\\/]");
 let usernameIsValid = function(username) {
   return !allowedUsernameCharacters.test(username);
 }
 let allowedCharactersString = "" +
-"<code>a-z</code>, " +
-"<code>0-9</code>, " +
+"lowercase letters, " +
+"digits, " +
 "<code>.</code>, " +
 "<code>_</code>, " +
 "<code>-</code>, " +

--- a/matrix_synapse_saml_mozilla/res/script.js
+++ b/matrix_synapse_saml_mozilla/res/script.js
@@ -65,9 +65,7 @@ let submitUsername = function(username) {
     return;
   }
 
-    // Since we're trying to register the username converted to lower case, check the
-    // availability with the right case.
-    let check_uri = 'check?' + buildQueryString({"username": username.toLowerCase()});
+    let check_uri = 'check?' + buildQueryString({"username": username});
     fetch(check_uri, {
         "credentials": "include",
     }).then((response) => {

--- a/matrix_synapse_saml_mozilla/res/script.js
+++ b/matrix_synapse_saml_mozilla/res/script.js
@@ -65,7 +65,9 @@ let submitUsername = function(username) {
     return;
   }
 
-    let check_uri = 'check?' + buildQueryString({"username": username});
+    // Since we're trying to register the username converted to lower case, check the
+    // availability with the right case.
+    let check_uri = 'check?' + buildQueryString({"username": username.toLowerCase()});
     fetch(check_uri, {
         "credentials": "include",
     }).then((response) => {

--- a/matrix_synapse_saml_mozilla/username_picker.py
+++ b/matrix_synapse_saml_mozilla/username_picker.py
@@ -155,8 +155,6 @@ class SubmitResource(AsyncResource):
             _return_html_error(400, "missing username", request)
             return
         localpart = request.args[b"username"][0].decode("utf-8", errors="replace")
-        # Convert the username to lower case.
-        localpart = localpart.lower()
         logger.info("Registering username %s", localpart)
         try:
             registered_user_id = await self._module_api.register_user(

--- a/matrix_synapse_saml_mozilla/username_picker.py
+++ b/matrix_synapse_saml_mozilla/username_picker.py
@@ -155,6 +155,8 @@ class SubmitResource(AsyncResource):
             _return_html_error(400, "missing username", request)
             return
         localpart = request.args[b"username"][0].decode("utf-8", errors="replace")
+        # Convert the username to lower case.
+        localpart = localpart.lower()
         logger.info("Registering username %s", localpart)
         try:
             registered_user_id = await self._module_api.register_user(


### PR DESCRIPTION
So that the user doesn't get dumped to a CSS-less error page telling
them that the localpart doesn't match the regexp.