### PR TITLE
Fix tests / CI

### DIFF
--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -33,8 +33,8 @@ from . import create_mapping_provider
 class FakeResponse:
     def __init__(self, source_uid, display_name):
         self.ava = {
-            "uid": [source_uid],
-            "emails": [],
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier": [source_uid],
+            "email": [],
         }
 
         if display_name:
@@ -50,19 +50,9 @@ def _load_test_response() -> AuthnResponse:
         "tests", "test_saml_response.xml"
     ).decode("utf-8")
 
-    config = SPConfig()
-    config.load(
-        {
-            "attribute_map_dir": pkg_resources.resource_filename(
-                "matrix_synapse_saml_mozilla", "saml_maps"
-            )
-        }
-    )
-    assert config.attribute_converters is not None
-
     response = AuthnResponse(
         sec_context=SecurityContext(FakeCryptoBackend()),
-        attribute_converters=config.attribute_converters,
+        attribute_converters={},
         entity_id="https://host/_matrix/saml2/metadata.xml",
         allow_unsolicited=True,
         allow_unknown_attributes=True,

--- a/tests/test_saml_response.xml
+++ b/tests/test_saml_response.xml
@@ -24,6 +24,7 @@
       </ns0:Attribute>
       <ns0:Attribute Name="email" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
         <ns0:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:string">testuser@domain.com</ns0:AttributeValue>
+        <ns0:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:string">other@otherdomain.com</ns0:AttributeValue>
       </ns0:Attribute>
       <ns0:Attribute Name="displayName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
         <ns0:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xsi:type="xs:string">Test Testuser</ns0:AttributeValue>


### PR DESCRIPTION
This fixes the tests so that CI will go ✅ .

The attribute mappings changed a few times in 12e759155a03def510b085e0cef3f31495531202, 705c37840774db8b1ae8bf1ef58a76e3b00c8147, and 198c5b967538827a0777e58cbd0b5d33f26b7cca. This updates the tests to use the current attributes:

https://github.com/matrix-org/matrix-synapse-saml-mozilla/blob/47349e88d5d6ddb52e10b68b0c9f7511b28d8299/matrix_synapse_saml_mozilla/mapping_provider.py#L40-L45